### PR TITLE
Drop now-deprecated phantomjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "karma-chrome-launcher": "^3.1.0",
         "karma-mocha": "^2.0.1",
         "karma-mocha-reporter": "^2.2.5",
-        "karma-phantomjs-launcher": "^1.0.4",
         "karma-sourcemap-loader": "^0.3.7",
         "karma-webpack": "^4.0.2",
         "mocha": "^7.2.0",
@@ -10613,16 +10612,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/karma-phantomjs-launcher": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.4.tgz",
-      "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.0.1",
-        "phantomjs-prebuilt": "^2.1.7"
-      }
-    },
     "node_modules/karma-sourcemap-loader": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz",
@@ -13654,26 +13643,6 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
-    },
-    "node_modules/phantomjs-prebuilt": {
-      "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.14.tgz",
-      "integrity": "sha1-1T0xH8+30dCN2yQBRVjxGIxRbaA=",
-      "dev": true,
-      "dependencies": {
-        "es6-promise": "~4.0.3",
-        "extract-zip": "~1.5.0",
-        "fs-extra": "~1.0.0",
-        "hasha": "~2.2.0",
-        "kew": "~0.7.0",
-        "progress": "~1.1.8",
-        "request": "~2.79.0",
-        "request-progress": "~2.0.1",
-        "which": "~1.2.10"
-      },
-      "bin": {
-        "phantomjs": "bin/phantomjs"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -29372,16 +29341,6 @@
         }
       }
     },
-    "karma-phantomjs-launcher": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.4.tgz",
-      "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.0.1",
-        "phantomjs-prebuilt": "^2.1.7"
-      }
-    },
     "karma-sourcemap-loader": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz",
@@ -31725,23 +31684,6 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
-    },
-    "phantomjs-prebuilt": {
-      "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.14.tgz",
-      "integrity": "sha1-1T0xH8+30dCN2yQBRVjxGIxRbaA=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "~4.0.3",
-        "extract-zip": "~1.5.0",
-        "fs-extra": "~1.0.0",
-        "hasha": "~2.2.0",
-        "kew": "~0.7.0",
-        "progress": "~1.1.8",
-        "request": "~2.79.0",
-        "request-progress": "~2.0.1",
-        "which": "~1.2.10"
-      }
     },
     "picocolors": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "karma-chrome-launcher": "^3.1.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
-    "karma-phantomjs-launcher": "^1.0.4",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^4.0.2",
     "mocha": "^7.2.0",


### PR DESCRIPTION
It doesn't seem like epub.js uses the now-deprecated phantomjs. Instead, per its `karma.conf.js`, it uses `ChromeHeadless`. This PR thus drops that dependency, fixing `arm64` build.

Fixes https://github.com/zotero/epub.js/issues/2